### PR TITLE
Fix ref error, use container settings from theme

### DIFF
--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -18,7 +18,7 @@ const Grid = styled('div')`
         (t) =>
           config(gridProps).container[t] &&
           config(gridProps).media[t]`
-        width: ${(props) => config(props).container[t]}rem;
+        width: ${(props) => config(gridProps).container[t]}rem;
       `
       )};
     `;


### PR DESCRIPTION
The package currently ignores the container settings in the emotion theme, reverting to the defaults. It looks like it's doing this because props is undefined, when it should be looking at `gridProps`.